### PR TITLE
pyamg 5.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 
 build_artifacts
+.DS_Store

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     number: 0
-    script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vv
+    script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
     build:
@@ -49,7 +49,6 @@ about:
         PyAMG is a library of Algebraic Multigrid (AMG) solvers with a convenient
         Python interface.
     doc_url: https://pypi.python.org/pypi/pyamg
-    doc_source_url: https://github.com/pyamg/pyamg
     dev_url: https://github.com/pyamg/pyamg
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
     number: 0
     script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+    missing_dso_whitelist:    # [s390x]
+        - "$RPATH/ld64.so.1"  # [s390x]
 
 requirements:
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyamg" %}
-{% set version = "4.2.3" %}
+{% set version = "5.2.1" %}
 
 package:
     name: {{ name }}
@@ -7,36 +7,34 @@ package:
 
 source:
     url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 37ad3c1dcaff2435c2ab7c8ec36942af0726c563d35059bcd18eb07473f7182e
+    sha256: f449d934224e503401ee72cd2eece1a29d893b7abe35f62a44d52ba831198efa
 
 build:
     number: 0
-    script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
-    skip: True   # [win and vc<14]
+    script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vv
 
 requirements:
     build:
         - {{ compiler('cxx') }}
     host:
         - python
-        - numpy
+        - pip
         - pybind11 >=2.8.0
         - setuptools >=42
-        - setuptools_scm >=5
+        - setuptools-scm >=7.0.0
         - toml
-        - pip
         - wheel
     run:
         - python
-        - {{ pin_compatible("numpy") }}
-        - scipy >=0.12.0
+        - numpy
+        - scipy >=1.11.0
 
 test:
+    imports:
+        - pyamg
     requires:
         - pip
         - pytest
-    imports:
-        - pyamg
     commands:
         - pip check
         - python -c "import pyamg; pyamg.test(verbose=True)"
@@ -48,8 +46,8 @@ about:
     license_family: MIT
     summary: Algebraic Multigrid Solvers in Python
     description: |
-      PyAMG is a library of Algebraic Multigrid (AMG) solvers with a convenient
-      Python interface.
+        PyAMG is a library of Algebraic Multigrid (AMG) solvers with a convenient
+        Python interface.
     doc_url: https://pypi.python.org/pypi/pyamg
     doc_source_url: https://github.com/pyamg/pyamg
     dev_url: https://github.com/pyamg/pyamg


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7416](https://anaconda.atlassian.net/browse/PKG-7416) 
- [Upstream repository](https://github.com/pyamg/pyamg/tree/v5.2.1)
- Requirements:
  - https://github.com/pyamg/pyamg/blob/v5.2.1/pyproject.toml
  - https://github.com/pyamg/pyamg/blob/v5.2.1/requirements.txt
  - https://github.com/pyamg/pyamg/blob/v5.2.1/setup.cfg 
  - https://github.com/pyamg/pyamg/blob/v5.2.1/setup.py

### Explanation of changes:

- Clean up the recipe by anaconda-linter --fix
- Add missing_dso_whitelist for s390x
- Update host and run dependencies
- Remove doc_source_url

### Notes:

-

[PKG-7416]: https://anaconda.atlassian.net/browse/PKG-7416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ